### PR TITLE
keyboard events fire custom data for rows and cols

### DIFF
--- a/keyboard.js
+++ b/keyboard.js
@@ -1,14 +1,3 @@
-// custom keypress events
-var customKeyDown = new Event('customkeydown', {
-		'view': window,
-    'bubbles': true
-});
-
-var customKeyUp = new Event('customkeyup', {
-		'view': window,
-    'bubbles': true
-});
-
 var keyboard = (function (){
 
 	var initialize = function(){
@@ -20,6 +9,7 @@ var keyboard = (function (){
 							<div class='keyboard-row'><span id='81'>Q</span> <span id='87'>W</span> <span id='69'>E</span> <span id='82'>R</span> <span id='84'>T</span> <span id='89'>Y</span> <span id='85'>U</span> <span id='73'>I</span> <span id='79'>O</span> <span id='80'>P</span> </div> \
 							<div class='keyboard-row'><span id='65'>A</span> <span id='83'>S</span> <span id='68'>D</span> <span id='70'>F</span> <span id='71'>G</span> <span id='72'>H</span> <span id='74'>J</span> <span id='75'>K</span> <span id='76'>L</span> </div> \
 							<div class='keyboard-row'><span id='90'>Z</span> <span id='88'>X</span> <span id='67'>C</span> <span id='86'>V</span> <span id='66'>B</span> <span id='78'>N</span> <span id='77'>M</span> </div>"
+
 		document.body.appendChild(keyboardDiv);
 
 		_setKeyboardHandler();
@@ -30,10 +20,15 @@ var keyboard = (function (){
 		var rows = aDiv.children;
 
 		for (var i = 0; i < rows.length; i++) {
+			rows[i].setAttribute('data-col', String(i) );
+
 			for (var j = 0; j < rows[i].children.length; j++) {
 				var elem = rows[i].children[j];
 				elem.addEventListener('mousedown',_mouseClicked);
 				elem.addEventListener('mouseup',_mouseReleased);
+
+				// add index
+				elem.setAttribute('data-row', String(j) );
 			}
 		}
 	};
@@ -44,33 +39,37 @@ var keyboard = (function (){
 	};
 
 	var _keyPressed = function(event){
-		console.log(event.keyCode);
 		var el = document.getElementById(''+event.keyCode+'');
 		if (!el) return;
 
-		if (el.getAttribute('data-pressed') === '1') {
-			return;
-		}
-
-		el.setAttribute('data-pressed', '1');
-		el.style.transition="background linear 0.1s";
-		el.style.background="#fe1";
-		el.dispatchEvent(customKeyDown);
+		triggerKeyDown(el);
 	};
 
 	var _keyReleased = function(event){
 		var el = document.getElementById(''+event.keyCode+'');
 		if (!el) return;
 
-		el.setAttribute('data-pressed', '0');
-		el.style.transition="background linear 0.1s";
-		el.style.background="#D9CB9E";
-		el.dispatchEvent(customKeyUp);
+		triggerKeyUp(el);
 	};
 
 	var _mouseClicked = function(event){
 		var el = document.getElementById(''+event.srcElement.id+'');
 
+		triggerKeyDown(el);
+	};
+
+	var _mouseReleased = function(event){
+		var el = document.getElementById(''+event.srcElement.id+'');
+		if (!el) return;
+		triggerKeyUp(el);
+	};
+
+	var setWidth = function(w){
+		document.getElementById('keyboard').style.width = ''+w+'px';
+	};
+
+	// called by both mouse and key events
+	var triggerKeyDown = function(el) {
 		if (el.getAttribute('data-pressed') === '1') {
 			return;
 		}
@@ -78,22 +77,32 @@ var keyboard = (function (){
 		el.setAttribute('data-pressed', '1');
 		el.style.transition="background linear 0.1s";
 		el.style.background="#fe1";
+
+		// dispatch custom event
+		var customKeyDown = new Event('customkeydown', {
+				'view': window,
+		    'bubbles': true
+		});
+		customKeyDown.colIndex = el.parentElement.getAttribute('data-col');
+		customKeyDown.rowIndex = el.getAttribute('data-row');
 		el.dispatchEvent(customKeyDown);
 	};
 
-	var _mouseReleased = function(event){
-		var el = document.getElementById(''+event.srcElement.id+'');
-
+	// called by both mouse and key events
+	var triggerKeyUp = function(el) {
 		el.setAttribute('data-pressed', '0');
 		el.style.transition="background linear 0.1s";
 		el.style.background="#D9CB9E";
-		// console.log(_keyState);
 
+		// dispatch custom event
+		var customKeyUp = new Event('customkeyup', {
+				'view': window,
+		    'bubbles': true
+		});
+
+		customKeyUp.colIndex = el.parentElement.getAttribute('data-col');
+		customKeyUp.rowIndex = el.getAttribute('data-row');
 		el.dispatchEvent(customKeyUp);
-	};
-
-	var setWidth = function(w){
-		document.getElementById('keyboard').style.width = ''+w+'px';
 	};
 
 	return{


### PR DESCRIPTION
keyboard rows are automatically assigned data-col, and the keys get a data-row. Then when a key is pressed, the row and column number are sent along with the custom event. I found this useful in what I'm working on right now so figured I'd add it!

Also, separated out the custom event firing routines into their own functions like this:
https://github.com/dennyabrain/KeyboardJS/pull/3/files#diff-56035df8f377cf2219374cd504d3b8caR92
